### PR TITLE
Change: max-width-x-small to base-number * 47 instead of 42

### DIFF
--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -476,7 +476,7 @@ $shell-container-maximum-width-large: $shell-g-base-number * 125 !default;
 
 $shell-container-maximum-width-small: $shell-g-base-number * 62.5 !default;
 
-$shell-container-maximum-width-x-small: $shell-g-base-number * 42 !default;
+$shell-container-maximum-width-x-small: $shell-g-base-number * 47 !default;
 
 
 /**


### PR DESCRIPTION
- Change the $shell-container-maximum-width-x-small to 47 up from 42 to
  match the container of entry point
