### PR TITLE
Update grid to use calc

### DIFF
--- a/src/_grid.scss
+++ b/src/_grid.scss
@@ -135,7 +135,6 @@
  *
  * 1. Allows the use of widths.
  * 2. Horizontal gutter.
- * 3. 100% width by default—"Mobile-first".
  *
  * N.B. all grid gutter sizes are in "Settings -> Grid (Local)".
  */
@@ -143,7 +142,6 @@
 .l-grid__item {
     flex-basis: auto; // [1]
     padding-left: rem($shell-g-spacing-base); // [2]
-    width: 100%; // [3]
 }
 
 

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -495,27 +495,29 @@ $shell-container-gutter: $shell-g-spacing-3x-large !default;
  * Grid column widths.
  */
 
-$shell-grid-1-col-width: 8.333% !default;
+$shell-grid-1-col-width: calc(100% / 12) !default;
 
-$shell-grid-2-col-width: 16.666% !default;
+$shell-grid-2-col-width: calc((100% / 12) * 2) !default;
 
 $shell-grid-3-col-width: 25% !default;
 
-$shell-grid-4-col-width: 33.333% !default;
+$shell-grid-4-col-width: calc((100% / 12) * 4) !default;
 
-$shell-grid-5-col-width: 41.666% !default;
+$shell-grid-5-col-width: calc((100% / 12) * 5) !default;
 
 $shell-grid-6-col-width: 50% !default;
 
-$shell-grid-7-col-width: 58.333% !default;
+$shell-grid-7-col-width: calc((100% / 12) * 7) !default;
 
-$shell-grid-8-col-width: 66.666% !default;
+$shell-grid-8-col-width: calc((100% / 12) * 8) !default;
 
 $shell-grid-9-col-width: 75% !default;
 
-$shell-grid-10-col-width: 83.333% !default;
+$shell-grid-10-col-width: calc((100% / 12) * 10) !default;
 
-$shell-grid-11-col-width: 91.666% !default;
+$shell-grid-11-col-width: calc((100% / 12) * 11) !default;
+
+$shell-grid-12-col-width: 100% !default;
 
 
 /**


### PR DESCRIPTION
Grid now uses `calc` to work out widths like 33.333%
Added a `--12-col: 100%`  so you don't have to override width if you're trying to do some flex manipulations
