### PR TITLE
Wbfe 71 rename base

### DIFF
--- a/src/_base.scss
+++ b/src/_base.scss
@@ -141,7 +141,7 @@ img {
 
 @if $shell-base-apply-bottom-margin-to-paragraphs {
     p {
-        margin-bottom: rem($shell-g-spacing-base);
+        margin-bottom: rem($shell-g-spacing);
 
         &:last-child {
             margin-bottom: 0;

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -34,8 +34,8 @@
 
 html {
     background: $shell-base-root-element-background-color;
-    color: $shell-g-color-text-base;
-    font-family: $shell-g-font-family-base;
+    color: $shell-g-color-text;
+    font-family: $shell-g-font-family;
     font-size: $shell-g-font-size / 16 * 1em;
     font-weight: $shell-g-font-weight-normal;
     line-height: $shell-g-line-height;
@@ -179,7 +179,7 @@ h3,
 h4,
 h5,
 h6 {
-    color: $shell-g-color-text-base;
+    color: $shell-g-color-text;
     font-size: rem($shell-g-font-size);
     font-weight: $shell-g-font-weight-normal;
     line-height: $shell-g-line-height;
@@ -191,7 +191,7 @@ h6 {
  */
 
 .heading {
-    color: $shell-g-color-text-base;
+    color: $shell-g-color-text;
     font-size: rem($shell-g-font-size);
     font-weight: $shell-g-font-weight-normal;
 }

--- a/src/_grid.scss
+++ b/src/_grid.scss
@@ -126,7 +126,7 @@
 .l-grid {
     display: flex;
     flex-flow: row wrap;
-    margin-left: -(rem($shell-g-spacing-base)); // [1]
+    margin-left: -(rem($shell-g-spacing)); // [1]
 }
 
 
@@ -142,7 +142,7 @@
 
 .l-grid__item {
     flex-basis: auto; // [1]
-    padding-left: rem($shell-g-spacing-base); // [2]
+    padding-left: rem($shell-g-spacing); // [2]
     width: 100%; // [3]
 }
 
@@ -183,10 +183,10 @@
 // N.B. having to reinstate the default so that any nested grids that inherit
 // a "Gutterless" modifier can be easily reapplied
 .l-grid--gutter-horizontal-base {
-    margin-left: -(rem($shell-g-spacing-base));
+    margin-left: -(rem($shell-g-spacing));
 
     > .l-grid__item {
-        padding-left:  rem($shell-g-spacing-base);
+        padding-left:  rem($shell-g-spacing);
     }
 }
 
@@ -233,7 +233,7 @@
 
 // Base
 .l-grid--gutter-vertical-base > .l-grid__item {
-    margin-bottom: rem($shell-g-spacing-base);
+    margin-bottom: rem($shell-g-spacing);
 }
 
 // Decrease

--- a/src/_grid.scss
+++ b/src/_grid.scss
@@ -182,7 +182,7 @@
 // Base
 // N.B. having to reinstate the default so that any nested grids that inherit
 // a "Gutterless" modifier can be easily reapplied
-.l-grid--gutter-horizontal-base {
+.l-grid--gutter-horizontal {
     margin-left: -(rem($shell-g-spacing));
 
     > .l-grid__item {
@@ -232,7 +232,7 @@
  */
 
 // Base
-.l-grid--gutter-vertical-base > .l-grid__item {
+.l-grid--gutter-vertical > .l-grid__item {
     margin-bottom: rem($shell-g-spacing);
 }
 

--- a/src/_helpers.scss
+++ b/src/_helpers.scss
@@ -57,7 +57,7 @@
  *   ever applies to multi-line declaration Helpers, applying a single-line
  *   declaration Helper, for example:
  *
-    .h-text-size-base {
+    .h-text-size {
         font-size: rem($shell-g-font-size) !important;
     }
  *
@@ -175,13 +175,13 @@
  * Base.
  */
 
-.h-text-size-base {
+.h-text-size {
     font-size: rem($shell-g-font-size) !important;
 }
 
 // Apply at breakpoints
-@if $shell-helper-apply-text-size-base-at-breakpoints {
-    @include apply-at-breakpoints(".h-text-size-base", $shell-helper-define-text-size-base-breakpoints) {
+@if $shell-helper-apply-text-size-at-breakpoints {
+    @include apply-at-breakpoints(".h-text-size", $shell-helper-define-text-size-breakpoints) {
         font-size: rem($shell-g-font-size) !important;
     }
 }

--- a/src/_helpers.scss
+++ b/src/_helpers.scss
@@ -523,14 +523,14 @@
  * Base.
  */
 
-.h-spacing-base {
-    margin-bottom: rem($shell-g-spacing-base) !important;
+.h-spacing {
+    margin-bottom: rem($shell-g-spacing) !important;
 }
 
 // Apply at breakpoints
-@if $shell-helper-apply-spacing-base-at-breakpoints {
-    @include apply-at-breakpoints('.h-spacing-base', $shell-helper-define-spacing-base-breakpoints) {
-        margin-bottom: rem($shell-g-spacing-base) !important;
+@if $shell-helper-apply-spacing-at-breakpoints {
+    @include apply-at-breakpoints('.h-spacing', $shell-helper-define-spacing-breakpoints) {
+        margin-bottom: rem($shell-g-spacing) !important;
     }
 }
 

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -193,29 +193,29 @@ $shell-g-font-weight-bold: 700 !default;
  * Increase: 24, 32, 40, 48, 56, 72, 96
  */
 
-$shell-g-spacing-base: $shell-g-base-number !default;
+$shell-g-spacing: $shell-g-base-number !default;
 
 // Decrease
-$shell-g-spacing-small: floor($shell-g-spacing-base - 4) !default;
+$shell-g-spacing-small: floor($shell-g-spacing - 4) !default;
 
-$shell-g-spacing-x-small: floor($shell-g-spacing-base / 2) !default;
+$shell-g-spacing-x-small: floor($shell-g-spacing / 2) !default;
 
-$shell-g-spacing-2x-small: floor($shell-g-spacing-base / 4) !default;
+$shell-g-spacing-2x-small: floor($shell-g-spacing / 4) !default;
 
 // Increase
-$shell-g-spacing-large: ceil($shell-g-spacing-base / 2 * 3) !default;
+$shell-g-spacing-large: ceil($shell-g-spacing / 2 * 3) !default;
 
-$shell-g-spacing-x-large: ceil($shell-g-spacing-base / 2 * 4) !default;
+$shell-g-spacing-x-large: ceil($shell-g-spacing / 2 * 4) !default;
 
-$shell-g-spacing-2x-large: ceil($shell-g-spacing-base / 2 * 5) !default;
+$shell-g-spacing-2x-large: ceil($shell-g-spacing / 2 * 5) !default;
 
-$shell-g-spacing-3x-large: ceil($shell-g-spacing-base / 2 * 6) !default;
+$shell-g-spacing-3x-large: ceil($shell-g-spacing / 2 * 6) !default;
 
-$shell-g-spacing-4x-large: ceil($shell-g-spacing-base / 2 * 7) !default;
+$shell-g-spacing-4x-large: ceil($shell-g-spacing / 2 * 7) !default;
 
-$shell-g-spacing-5x-large: ceil($shell-g-spacing-base / 2 * 9) !default;
+$shell-g-spacing-5x-large: ceil($shell-g-spacing / 2 * 9) !default;
 
-$shell-g-spacing-6x-large: ceil($shell-g-spacing-base / 2 * 12) !default;
+$shell-g-spacing-6x-large: ceil($shell-g-spacing / 2 * 12) !default;
 
 
 
@@ -718,9 +718,9 @@ $shell-helper-define-hide-visually-breakpoints: $shell-g-global-breakpoints !def
  * Base.
  */
 
-$shell-helper-apply-spacing-base-at-breakpoints: false !default;
+$shell-helper-apply-spacing-at-breakpoints: false !default;
 
-$shell-helper-define-spacing-base-breakpoints: $shell-g-global-breakpoints !default;
+$shell-helper-define-spacing-breakpoints: $shell-g-global-breakpoints !default;
 
 /**
  * Decrease from base.

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -101,7 +101,7 @@ $shell-g-color-black: #000 !default;
  * Base text.
  */
 
-$shell-g-color-text-base: #434d5d !default;
+$shell-g-color-text: #434d5d !default;
 
 
 /**
@@ -164,7 +164,7 @@ $shell-g-line-height: 1.5 !default;
  */
 
 // Base
-$shell-g-font-family-base: 'Helvetica Neue', sans-serif !default;
+$shell-g-font-family: 'Helvetica Neue', sans-serif !default;
 
 // Mono-space
 $shell-g-font-family-monospace: monospace, monospace !default;
@@ -437,7 +437,7 @@ $shell-base-hr-thickness: 1px !default;
 
 $shell-base-hr-style: solid !default;
 
-$shell-base-hr-color: $shell-g-color-text-base !default;
+$shell-base-hr-color: $shell-g-color-text !default;
 
 
 /**
@@ -600,9 +600,9 @@ $shell-grid-define-11-col-width-breakpoints: $shell-g-global-breakpoints !defaul
  * Base.
  */
 
-$shell-helper-apply-text-size-base-at-breakpoints: false !default;
+$shell-helper-apply-text-size-at-breakpoints: false !default;
 
-$shell-helper-define-text-size-base-breakpoints: $shell-g-global-breakpoints !default;
+$shell-helper-define-text-size-breakpoints: $shell-g-global-breakpoints !default;
 
 /**
  * Decrease from base.

--- a/src/_side-by-side.scss
+++ b/src/_side-by-side.scss
@@ -110,11 +110,11 @@
 // Base
 // N.B. having to reinstate the default so that any nested "Side-by-side's"
 // that inherit a "Gutterless" modifier can be easily reapplied
-.l-side-by-side--gutter-base > .l-side-by-side__item:last-child {
+.l-side-by-side--gutter > .l-side-by-side__item:last-child {
     margin-left: rem($shell-g-spacing);
 }
 
-.l-side-by-side--gutter-base.l-side-by-side--reversed > .l-side-by-side__item:last-child {
+.l-side-by-side--gutter.l-side-by-side--reversed > .l-side-by-side__item:last-child {
     margin-left: 0;
     margin-right: rem($shell-g-spacing);
 }

--- a/src/_side-by-side.scss
+++ b/src/_side-by-side.scss
@@ -74,13 +74,13 @@
 // The last item
 .l-side-by-side__item:last-child {
     flex: 1 1 0%; // [1]
-    margin-left: rem($shell-g-spacing-base); // [2]
+    margin-left: rem($shell-g-spacing); // [2]
 }
 
 // Reversing the gutters for the "Reversed" modifier
 .l-side-by-side--reversed > .l-side-by-side__item:last-child {
     margin-left: 0;
-    margin-right: rem($shell-g-spacing-base);
+    margin-right: rem($shell-g-spacing);
 }
 
 
@@ -111,12 +111,12 @@
 // N.B. having to reinstate the default so that any nested "Side-by-side's"
 // that inherit a "Gutterless" modifier can be easily reapplied
 .l-side-by-side--gutter-base > .l-side-by-side__item:last-child {
-    margin-left: rem($shell-g-spacing-base);
+    margin-left: rem($shell-g-spacing);
 }
 
 .l-side-by-side--gutter-base.l-side-by-side--reversed > .l-side-by-side__item:last-child {
     margin-left: 0;
-    margin-right: rem($shell-g-spacing-base);
+    margin-right: rem($shell-g-spacing);
 }
 
 // Decrease


### PR DESCRIPTION
Removal of `-base` from scales across all files.

There are some I have left as they seemed to be less to do with scales and more to do with the originating file.

e.g:
`$shell-g-base-number`
`$shell-base-hr-thickness`
