### PR TITLE
Add line-height of 1 for textual inputs

### DIFF
--- a/src/_base.scss
+++ b/src/_base.scss
@@ -130,6 +130,15 @@ img {
 }
 
 
+/**
+ * Allows textual input values to be positioned by padding alone.
+ */
+
+#{$shell-g-textual-inputs} {
+    line-height: 1;
+}
+
+
 
 
 /* 6. Paragraphs

--- a/src/_normalise-reset.scss
+++ b/src/_normalise-reset.scss
@@ -660,6 +660,15 @@ progress {
 
 
     /**
+     * Allows textual input values to be positioned by padding alone.
+     */
+
+    #{$shell-g-textual-inputs} {
+        line-height: 1;
+    }
+
+
+    /**
      * Remove the top inner shadow from iOS inputs. See:
      * https://davidwalsh.name/input-shadows-ipad
      */

--- a/src/_normalise-reset.scss
+++ b/src/_normalise-reset.scss
@@ -660,15 +660,6 @@ progress {
 
 
     /**
-     * Allows textual input values to be positioned by padding alone.
-     */
-
-    #{$shell-g-textual-inputs} {
-        line-height: 1;
-    }
-
-
-    /**
      * Remove the top inner shadow from iOS inputs. See:
      * https://davidwalsh.name/input-shadows-ipad
      */


### PR DESCRIPTION
Reset text inputs `line-height` to enable positioning via padding
