### PR TITLE
Issue 79: Removing disabled and readonly base styles

### DIFF
--- a/src/_base.scss
+++ b/src/_base.scss
@@ -19,10 +19,9 @@
  * 1. Root element
  * 2. Links
  * 3. Images
- * 4. Forms
- * 5. Paragraphs
- * 6. Headings
- * 7. Print
+ * 4. Paragraphs
+ * 5. Headings
+ * 6. Print
  */
 
 
@@ -102,31 +101,7 @@ img {
 
 
 
-/* 4. Forms
-   ========================================================================= */
-
-/**
- * Apply an optional `opacity` style for disabled and read-only states.
- *
- * N.B. if developing for iOS be aware of this bug:
- * "Safari Mobile for iOS applies a default style of `opacity: 0.4` to disabled
- * textual `<input>` elements. Other major browsers don't currently share this
- * particular default style."
- * —https://developer.mozilla.org/en-US/docs/Web/HTML/Element/
- * Input#Browser_compatibility
- */
-
-@if $shell-base-apply-style-to-disabled-and-readonly-states {
-    :disabled,
-    [readonly] {
-        opacity: $shell-base-disabled-and-readonly-state-opacity-strength;
-    }
-}
-
-
-
-
-/* 5. Paragraphs
+/* 4. Paragraphs
    ========================================================================= */
 
 /**
@@ -142,7 +117,7 @@ img {
 
 
 
-/* 6. Headings
+/* 5. Headings
    ========================================================================= */
 
 /**
@@ -195,7 +170,7 @@ h6 {
 
 
 
-/* 7. Print
+/* 6. Print
    ========================================================================= */
 
 /**

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -393,14 +393,13 @@ $shell-g-textual-inputs: 'input[type="text"],
 
 
 
+
 /* 10. Base (Local)
    ========================================================================= */
 
 /**
  * Booleans.
  */
-
-$shell-base-apply-style-to-disabled-and-readonly-states: true !default;
 
 $shell-base-apply-bottom-margin-to-paragraphs: false !default;
 
@@ -419,15 +418,6 @@ $shell-base-root-element-background-color: $shell-g-color-white !default;
 $shell-base-link-text-decoration: underline !default;
 
 $shell-base-link-text-decoration-on-hover: none !default;
-
-
-/**
- * Forms.
- */
-
-$shell-base-disabled-and-readonly-state-opacity-strength: 0.6 !default;
-
-$shell-base-target-ios-selector: '.target-ios' !default;
 
 
 


### PR DESCRIPTION
Fixes #79.

Also removed this unused setting: `$shell-base-target-ios-selector`.