### PR TITLE
Issue 72: Apply the "cm-stylelint" NPM module

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,3 @@
 {
-    "extends": "./stylelint.config.js"
+    'extends': './stylelint.config.js'
 }

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ project root/
 # Linting
 
 [stylelint](http://stylelint.io/) is used for linting and Shell follows these
-[CSS guidelines](https://github.com/chris-pearce/css-guidelines).
+[CSS guidelines](https://git.campmon.com/Architecture/coding-conventions/blob/master/css/README.md) applied by [stylelint.config.js](stylelint.config.js).
 
 *Eventually linting will be setup as part of CI, see: #19.*
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ project root/
 
 *Eventually linting will be setup as part of CI, see: #19.*
 
+For now you can go to your Terminal `cd` into the root of Shell and run:
+
+```sh
+gulp lint
+```
+
+This will lint all of the Shell source `.scss` files including `test` and `docs`.
+
 
 # Browser Support
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,6 @@
         "grunt-postcss": "^0.7.1",
         "grunt-sass": "^1.1.0",
         "grunt-svgmin": "^2.0.1",
-        "stylelint": "^6.5.1"
+        "stylelint": "^7.6.0"
     }
 }

--- a/docs/src/assets/scss/_base.scss
+++ b/docs/src/assets/scss/_base.scss
@@ -52,9 +52,9 @@ $heading-anchor-icon-size:  36px;
  */
 
 .heading__anchor {
+    /* stylelint-disable-next-line color-named */
     background: aqua;
     bottom: 4px;
-    //left: -32px;
     left: 0;
     line-height: 0;
     position: absolute;

--- a/docs/src/assets/scss/_settings.scss
+++ b/docs/src/assets/scss/_settings.scss
@@ -57,8 +57,8 @@ $g-color-code-navy-blue: #000080;
 /* 2. Typography
    ========================================================================= */
 
-$g-font-family-light: 'HelveticaNeue-Light', 'Helvetica Neue Light',
-'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+/* stylelint-disable-next-line max-line-length */
+$g-font-family-light: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,23 @@
+var gulp = require('gulp');
+var postcss = require('gulp-postcss');
+var reporter = require('postcss-reporter');
+var stylelint = require('stylelint');
+var syntaxScss = require('postcss-scss');
+
+var lintCSSFiles = [
+    'src/**/*.scss',
+    'docs/src/**/*.scss',
+    'test/src/**/*.scss',
+    '!node_modules/**',
+];
+
+gulp.task('lint', function () {
+    var processors = [
+        stylelint(),
+        reporter({
+            clearMessages: true,
+            throwError: false
+        })
+    ];
+    return gulp.src(lintCSSFiles).pipe(postcss(processors, {syntax: syntaxScss}));
+});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "url": "https://github.com/campaignmonitor/shell/issues"
     },
     "devDependencies": {
-        "stylelint": "^6.5.1"
+        "stylelint": "^7.6.0"
     },
     "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
         "url": "https://github.com/campaignmonitor/shell/issues"
     },
     "devDependencies": {
-        "stylelint": "^7.6.0"
+        "stylelint": "^7.6.0",
+        "gulp": "^3.9.1",
+        "gulp-postcss": "^6.2.0",
+        "postcss-reporter": "^1.4.1",
+        "postcss-scss": "^0.4.0"
     },
     "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "type": "git",
         "url":  "git@github.com:campaignmonitor/shell.git"
     },
-        "bugs": {
+    "bugs": {
         "url": "https://github.com/campaignmonitor/shell/issues"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-    "name": "shell-csslib",
-    "version": "1.2.0",
-    "description": "A powerful, lightweight, unopinionated, responsive friendly CSS library that provides a solid foundation for any UI build. Developed at Campaign Monitor",
-    "homepage": "https://github.com/campaignmonitor/shell",
-    "keywords": [
-        "shell",
-        "css",
-        "library",
-        "sass",
-        "bem",
-        "responsive"
-    ],
-    "main": "index.js",
-    "author": [
-        {
-            "name": "Chris Pearce",
-            "email": "chrisp@campaignmonitor.com",
-            "url": "http://chris-pearce.me"
-        },
-        {
-            "name": "Dave Berner",
-            "email": "daveb@campaignmonitor.com",
-            "url": "http://davidberner.co.uk/"
-        }
-    ],
-    "repository": {
-        "type": "git",
-        "url":  "git@github.com:campaignmonitor/shell.git"
+  "name": "shell-csslib",
+  "version": "1.2.0",
+  "description": "A powerful, lightweight, unopinionated, responsive friendly CSS library that provides a solid foundation for any UI build. Developed at Campaign Monitor",
+  "homepage": "https://github.com/campaignmonitor/shell",
+  "keywords": [
+    "shell",
+    "css",
+    "library",
+    "sass",
+    "bem",
+    "responsive"
+  ],
+  "main": "index.js",
+  "author": [
+    {
+      "name": "Chris Pearce",
+      "email": "chrisp@campaignmonitor.com",
+      "url": "http://chris-pearce.me"
     },
-    "bugs": {
-        "url": "https://github.com/campaignmonitor/shell/issues"
-    },
-    "devDependencies": {
-        "stylelint": "^7.6.0",
-        "gulp": "^3.9.1",
-        "gulp-postcss": "^6.2.0",
-        "postcss-reporter": "^1.4.1",
-        "postcss-scss": "^0.4.0"
-    },
-    "license": "MIT"
+    {
+      "name": "Dave Berner",
+      "email": "daveb@campaignmonitor.com",
+      "url": "http://davidberner.co.uk/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:campaignmonitor/shell.git"
+  },
+  "bugs": {
+    "url": "https://github.com/campaignmonitor/shell/issues"
+  },
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-postcss": "^6.2.0",
+    "postcss-reporter": "^1.4.1",
+    "postcss-scss": "^0.4.0",
+    "stylelint": "^7.6.0"
+  },
+  "license": "MIT"
 }

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -202,15 +202,6 @@ h6 {
 
 
     /**
-     * Apply bottom margin to all paragraphs.
-     */
-
-    p:not(:last-child) {
-        margin-bottom: rem($shell-g-spacing) !important;
-    }
-
-
-    /**
      * Make links always stand out.
      */
 
@@ -269,8 +260,6 @@ h6 {
      * Page breaks.
      */
 
-    /* stylelint-disable no-descending-specificity */
-
     h2,
     h3 {
         page-break-after: avoid;
@@ -298,5 +287,11 @@ h6 {
         widows: 3;
     }
 
-    /* stylelint-enable no-descending-specificity */
+    /**
+     * Apply bottom margin to all paragraphs.
+     */
+
+    p:not(:last-child) {
+        margin-bottom: rem($shell-g-spacing) !important;
+    }
 }

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -153,9 +153,11 @@ h6 {
      * Global.
      */
 
+    /* stylelint-disable selector-no-universal */
     *,
     *::after,
     *::before,
+    /* stylelint-enable */
     // First letter
     blockquote::first-letter,
     div::first-letter,

--- a/src/_grid.scss
+++ b/src/_grid.scss
@@ -437,15 +437,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-1-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--1-col', $shell-grid-define-1-col-width-breakpoints) {
         width: $shell-grid-1-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 2 col
 .l-grid__item--2-col {
@@ -453,15 +450,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-2-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--2-col', $shell-grid-define-2-col-width-breakpoints) {
         width: $shell-grid-2-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 3 col
 .l-grid__item--3-col {
@@ -469,15 +463,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-3-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--3-col', $shell-grid-define-3-col-width-breakpoints) {
         width: $shell-grid-3-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 4 col
 .l-grid__item--4-col {
@@ -485,15 +476,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-4-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--4-col', $shell-grid-define-4-col-width-breakpoints) {
         width: $shell-grid-4-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 5 col
 .l-grid__item--5-col {
@@ -501,15 +489,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-5-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--5-col', $shell-grid-define-5-col-width-breakpoints) {
         width: $shell-grid-5-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 6 col
 .l-grid__item--6-col {
@@ -517,15 +502,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-6-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--6-col', $shell-grid-define-6-col-width-breakpoints) {
         width: $shell-grid-6-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 7 col
 .l-grid__item--7-col {
@@ -533,15 +515,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-7-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--7-col', $shell-grid-define-7-col-width-breakpoints) {
         width: $shell-grid-7-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 8 col
 .l-grid__item--8-col {
@@ -549,15 +528,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-8-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--8-col', $shell-grid-define-8-col-width-breakpoints) {
         width: $shell-grid-8-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 9 col
 .l-grid__item--9-col {
@@ -565,15 +541,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-9-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--9-col', $shell-grid-define-9-col-width-breakpoints) {
         width: $shell-grid-9-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 10 col
 .l-grid__item--10-col {
@@ -581,15 +554,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-10-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--10-col', $shell-grid-define-10-col-width-breakpoints) {
         width: $shell-grid-10-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 11 col
 .l-grid__item--11-col {
@@ -597,15 +567,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-11-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--11-col', $shell-grid-define-11-col-width-breakpoints) {
         width: $shell-grid-11-col-width;
     }
 }
-
-/* stylelint-enable */
 
 // 12 col
 .l-grid__item--12-col {
@@ -613,12 +580,9 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-grid-apply-12-col-width-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.l-grid__item--12-col', $shell-grid-define-12-col-width-breakpoints) {
         width: $shell-grid-12-col-width;
     }
 }
-
-/* stylelint-enable */

--- a/src/_helpers.scss
+++ b/src/_helpers.scss
@@ -186,15 +186,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-at-breakpoints {
-    @include apply-at-breakpoints('.h-text-size', $shell-helper-define-text-size-breakpoints) {
+    /* stylelint-disable-next-line max-line-length */
+    @include apply-at-breakpoints('.h-text-size',$shell-helper-define-text-size-breakpoints) {
         font-size: rem($shell-g-font-size) !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -207,15 +204,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-small-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-small', $shell-helper-define-text-size-small-breakpoints) {
         font-size: rem($shell-g-font-size-small) !important;
     }
 }
-
-/* stylelint-enable */
 
 // X-small
 .h-text-size-x-small {
@@ -223,15 +217,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-x-small-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-x-small', $shell-helper-define-text-size-x-small-breakpoints) {
         font-size: rem($shell-g-font-size-x-small) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 2X-small
 .h-text-size-2x-small {
@@ -239,15 +230,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-x-small-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-2x-small', $shell-helper-define-text-size-2x-small-breakpoints) {
         font-size: rem($shell-g-font-size-2x-small) !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -260,15 +248,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-large', $shell-helper-define-text-size-large-breakpoints) {
         font-size: rem($shell-g-font-size-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // X-Large
 .h-text-size-x-large {
@@ -276,15 +261,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-x-large', $shell-helper-define-text-size-x-large-breakpoints) {
         font-size: rem($shell-g-font-size-x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 2X-Large
 .h-text-size-2x-large {
@@ -292,15 +274,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-2x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-2x-large', $shell-helper-define-text-size-2x-large-breakpoints) {
         font-size: rem($shell-g-font-size-2x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 3X-Large
 .h-text-size-3x-large {
@@ -308,15 +287,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-3x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-3x-large', $shell-helper-define-text-size-3x-large-breakpoints) {
         font-size: rem($shell-g-font-size-3x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 4X-Large
 .h-text-size-4x-large {
@@ -324,15 +300,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-4x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-4x-large', $shell-helper-define-text-size-4x-large-breakpoints) {
         font-size: rem($shell-g-font-size-4x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 5X-Large
 .h-text-size-5x-large {
@@ -340,15 +313,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-5x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-5x-large', $shell-helper-define-text-size-5x-large-breakpoints) {
         font-size: rem($shell-g-font-size-5x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 6X-Large
 .h-text-size-6x-large {
@@ -356,15 +326,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-6x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-6x-large', $shell-helper-define-text-size-6x-large-breakpoints) {
         font-size: rem($shell-g-font-size-6x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 7X-Large
 .h-text-size-7x-large {
@@ -372,15 +339,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-size-7x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-size-7x-large', $shell-helper-define-text-size-7x-large-breakpoints) {
         font-size: rem($shell-g-font-size-7x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -393,15 +357,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-align-center-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-align-center', $shell-helper-define-text-align-center-breakpoints) {
         text-align: center !important;
     }
 }
-
-/* stylelint-enable */
 
 // Left
 .h-text-align-left {
@@ -409,30 +370,24 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-align-left-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-align-left', $shell-helper-define-text-align-left-breakpoints) {
         text-align: left !important;
     }
 }
-
-/* stylelint-enable */
 // Right
 .h-text-align-right {
     text-align: right !important;
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-align-right-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-align-right', $shell-helper-define-text-align-right-breakpoints) {
         text-align: right !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -456,15 +411,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-truncate-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-truncate', $shell-helper-define-text-truncate-breakpoints) {
         @include text-truncate(true);
     }
 }
-
-/* stylelint-enable */
 
 /**
  * Modifier: inline.
@@ -475,15 +427,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-truncate-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-truncate--inline', $shell-helper-define-text-truncate-breakpoints) {
         display: inline-block !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -499,15 +448,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-text-wrap-word-and-hyphenate-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-text-wrap-word-and-hyphenate', $shell-helper-define-text-wrap-word-and-hyphenate-breakpoints) {
         @include text-wrap-word-and-hyphenate(true);
     }
 }
-
-/* stylelint-enable */
 
 
 
@@ -524,15 +470,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-hide-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-hide', $shell-helper-define-hide-breakpoints) {
         display: none !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -546,15 +489,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-hide-visually-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-hide-visually', $shell-helper-define-hide-visually-breakpoints) {
         @include hide-visually(true);
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -635,15 +575,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing', $shell-helper-define-spacing-breakpoints) {
         margin-bottom: rem($shell-g-spacing) !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -656,15 +593,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-small-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-small', $shell-helper-define-spacing-small-breakpoints) {
         margin-bottom: rem($shell-g-spacing-small) !important;
     }
 }
-
-/* stylelint-enable */
 
 // X-Small
 .h-spacing-x-small {
@@ -672,15 +606,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-x-small-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-x-small', $shell-helper-define-spacing-x-small-breakpoints) {
         margin-bottom: rem($shell-g-spacing-x-small) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 2X-Small
 .h-spacing-2x-small {
@@ -688,15 +619,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-2x-small-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-2x-small', $shell-helper-define-spacing-2x-small-breakpoints) {
         margin-bottom: rem($shell-g-spacing-2x-small) !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -709,15 +637,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-large', $shell-helper-define-spacing-large-breakpoints) {
         margin-bottom: rem($shell-g-spacing-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // X-Large
 .h-spacing-x-large {
@@ -725,15 +650,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-x-large', $shell-helper-define-spacing-x-large-breakpoints) {
         margin-bottom: rem($shell-g-spacing-x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 2X-Large
 .h-spacing-2x-large {
@@ -741,15 +663,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-2x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-2x-large', $shell-helper-define-spacing-2x-large-breakpoints) {
         margin-bottom: rem($shell-g-spacing-2x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 3X-Large
 .h-spacing-3x-large {
@@ -757,15 +676,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-3x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-3x-large', $shell-helper-define-spacing-3x-large-breakpoints) {
         margin-bottom: rem($shell-g-spacing-3x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 4X-Large
 .h-spacing-4x-large {
@@ -773,15 +689,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-4x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-4x-large', $shell-helper-define-spacing-4x-large-breakpoints) {
         margin-bottom: rem($shell-g-spacing-4x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 5X-Large
 .h-spacing-5x-large {
@@ -789,15 +702,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-5x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-5x-large', $shell-helper-define-spacing-5x-large-breakpoints) {
         margin-bottom: rem($shell-g-spacing-5x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 // 6X-Large
 .h-spacing-6x-large {
@@ -805,15 +715,12 @@
 }
 
 // Apply at breakpoints
-/* stylelint-disable max-line-length */
-
 @if $shell-helper-apply-spacing-6x-large-at-breakpoints {
+    /* stylelint-disable-next-line max-line-length */
     @include apply-at-breakpoints('.h-spacing-6x-large', $shell-helper-define-spacing-6x-large-breakpoints) {
         margin-bottom: rem($shell-g-spacing-6x-large) !important;
     }
 }
-
-/* stylelint-enable */
 
 
 /**

--- a/src/_mixins-functions.scss
+++ b/src/_mixins-functions.scss
@@ -224,11 +224,8 @@
 
 @function rem($value) {
     @if type-of($value) != 'number' {
-        /* stylelint-disable max-line-length */
-
+        /* stylelint-disable-next-line max-line-length */
         @error 'You have to enter only a number for `$value`. You entered #{$value}`.';
-
-        /* stylelint-enable */
     }
     @return strip-unit($value) / strip-unit($shell-g-font-size) * 1rem;
 }
@@ -370,12 +367,8 @@
     @if length($breakpoints) == 2 and index((min max), nth($breakpoints, 2)) {
         $breakpoints-copy: $breakpoints;
         $breakpoints: ();
-
-        /* stylelint-disable max-line-length */
-
+        /* stylelint-disable-next-line max-line-length */
         $breakpoints: append($breakpoints, (nth($breakpoints-copy, 1) nth($breakpoints-copy, 2)));
-
-        /* stylelint-enable */
     }
 
     // Loop through all the breakpoints passed in from the Shell consumer side
@@ -411,16 +404,13 @@
         // `bp()` so that we can generate the breakpoint value correctly
         $generate-breakpoint: $breakpoint;
 
-        /* stylelint-disable block-closing-brace-newline-after */
-
         @if type-of($breakpoint) == 'number' {
             $breakpoint: strip-unit($breakpoint);
             $generate-breakpoint: em($breakpoint, 16);
-        } @else {
+        }
+        @else {
             $generate-breakpoint: bp($breakpoint);
         }
-
-        /* stylelint-enable */
 
         // Change the limit label when a "max" limit is used
         @if $limit == $limit-max {
@@ -438,11 +428,8 @@
             // `.h-hide-visually-from-900`
             // `.h-hide-visually-up-to-palm`
 
-            /* stylelint-disable max-line-length */
-
+            /* stylelint-disable-next-line max-line-length */
             $generated-selector: '#{$class-selector}-#{$limit-label}-#{$breakpoint}';
-
-            /* stylelint-enable */
 
             // The contents of the media query
             #{$generated-selector} {
@@ -513,11 +500,8 @@
 
 @function bp($breakpoint) {
     @if not map-has-key($shell-g-breakpoints, $breakpoint) {
-        /* stylelint-disable max-line-length */
-
+        /* stylelint-disable-next-line max-line-length */
         @error 'Sorry but `#{$breakpoint}` doesn\'t exist as a breakpoint name in the \'Breakpoints\' map.';
-
-        /* stylelint-enable */
     }
     @return map-get($shell-g-breakpoints, $breakpoint);
 }
@@ -553,18 +537,19 @@
 ///         z-index: 1;
 ///     }
 
-/* stylelint-disable */
 @function z($z-index-layer, $z-index-layer-nested: null) {
     @if not map-has-key($shell-g-z-layers, $z-index-layer) {
+        /* stylelint-disable-next-line max-line-length */
         @error 'Sorry but `#{$z-index-layer}` doesn\'t exist as a `z-index` name in the \'Z-Index system\' map.';
     }
     @if ($z-index-layer-nested != null) {
+        /* stylelint-disable-next-line max-line-length */
         @return map-get(map-get($shell-g-z-layers, $z-index-layer), $z-index-layer-nested);
-    } @else {
+    }
+    @else {
         @return map-get($shell-g-z-layers, $z-index-layer);
     }
 }
-/* stylelint-enable */
 
 
 
@@ -651,6 +636,7 @@
 @mixin text-truncate($apply-important-keyword: false, $display: block) {
     $important-keyword: if($apply-important-keyword, ' !important', '');
     $display-property-value: if($display == block, 'block', $display);
+
     display: #{$display-property-value}#{$important-keyword};
     overflow: hidden#{$important-keyword};
     text-overflow: ellipsis#{$important-keyword};
@@ -687,6 +673,7 @@
 
 @mixin text-osx-font-smoothing($apply-important-keyword: false) {
     $important-keyword: if($apply-important-keyword, ' !important', '');
+
     -moz-osx-font-smoothing: grayscale#{$important-keyword};
     -webkit-font-smoothing: antialiased#{$important-keyword};
 }
@@ -773,15 +760,12 @@
 @mixin hide-visually($apply-important-keyword: false) {
     $important-keyword: if($apply-important-keyword, ' !important', '');
 
-    /* stylelint-disable function-whitespace-after */
-
     // `clip` is deprecated but we keep it for browsers that don't support
     // `clip-path`
+    /* stylelint-disable function-whitespace-after */
     clip: rect(1px, 1px, 1px, 1px)#{$important-keyword};
     clip-path: polygon(0 0, 0 0, 0 0, 0 0)#{$important-keyword};
-
     /* stylelint-enable */
-
     height: 1px#{$important-keyword};
     overflow: hidden#{$important-keyword};
     position: absolute#{$important-keyword};
@@ -823,6 +807,7 @@
 
 @mixin align-horizontally-and-vertically($apply-important-keyword: false) {
     $important-keyword: if($apply-important-keyword, ' !important', '');
+
     align-items: center#{$important-keyword};
     display: flex#{$important-keyword};
     flex-flow: column;
@@ -864,15 +849,12 @@
 
 @mixin align-horizontally-and-vertically-alt($apply-important-keyword: false) {
     $important-keyword: if($apply-important-keyword, ' !important', '');
+
     left: 50%#{$important-keyword};
     position: absolute#{$important-keyword};
     top: 50%#{$important-keyword};
-
-    /* stylelint-disable function-whitespace-after */
-
+    /* stylelint-disable-next-line function-whitespace-after */
     transform: translate(-50%, -50%)#{$important-keyword};
-
-    /* stylelint-enable */
 }
 
 
@@ -918,16 +900,12 @@
     @if length($ratio) < 2 or length($ratio) > 2 {
         @error '#{inspect($ratio)} must be a list with two values.';
     }
+
     display: block#{$important-keyword};
     height: 0#{$important-keyword};
     overflow: hidden#{$important-keyword};
-
-    /* stylelint-disable max-line-length, function-whitespace-after */
-
+    /* stylelint-disable-next-line function-whitespace-after, max-line-length */
     padding-bottom: percentage(nth($ratio, 2) / nth($ratio, 1))#{$important-keyword};
-
-    /* stylelint-enable */
-
     position: relative#{$important-keyword};
 }
 

--- a/src/_mixins-functions.scss
+++ b/src/_mixins-functions.scss
@@ -103,10 +103,8 @@
 ///     }
 
 @mixin hidpi-bg-img($img-url, $img-width: auto, $img-height: auto) {
-    /* stylelint-disable */
     @media (min-resolution: $shell-g-hidpi-dppx),
            (min-resolution: $shell-g-hidpi-dpi) {
-    /* stylelint-enable */
         background-image: url('#{$img-url}');
         background-size: $img-width $img-height;
     }

--- a/src/_normalise-reset.scss
+++ b/src/_normalise-reset.scss
@@ -51,11 +51,13 @@ html {
 }
 
 // [1]
+/* stylelint-disable selector-no-universal */
 *,
 *::before,
 *::after {
     box-sizing: inherit;
 }
+/* stylelint-enable */
 
 
 /**
@@ -244,6 +246,7 @@ video {
 
 a {
     background-color: transparent; // [1]
+    /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-text-decoration-skip: objects; // [2]
 }
 
@@ -266,10 +269,9 @@ a:hover {
 
 abbr[title] {
     border-bottom: none; // [1]
-    /* stylelint-disable declaration-block-no-duplicate-properties */
     text-decoration: underline; // [2]
+    /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
     text-decoration: underline dotted; // [2]
-    /* stylelint-enable */
 }
 
 
@@ -287,14 +289,11 @@ strong {
  * Add the correct font weight in Chrome, Edge, and Safari.
  */
 
-/* stylelint-disable no-duplicate-selectors */
-
+/* stylelint-disable-next-line no-duplicate-selectors */
 b,
 strong {
     font-weight: bolder;
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -311,11 +310,8 @@ dfn {
  */
 
 small {
-    /* stylelint-disable property-unit-whitelist */
-
+    /* stylelint-disable-next-line declaration-property-unit-whitelist */
     font-size: 100%;
-
-    /* stylelint-enable */
 }
 
 
@@ -325,11 +321,8 @@ small {
 
 sub,
 sup {
-    /* stylelint-disable property-unit-whitelist */
-
+    /* stylelint-disable-next-line declaration-property-unit-whitelist */
     font-size: 75%;
-
-    /* stylelint-enable */
     line-height: 0;
     position: relative;
     vertical-align: baseline;
@@ -451,9 +444,8 @@ button,
 html [type='button'], // [1]
 [type='reset'],
 [type='submit'] {
-    /* stylelint-disable property-no-vendor-prefix */
+    /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: button; // [3]
-    /* stylelint-enable */
     cursor: pointer; // [2]
 }
 
@@ -521,15 +513,11 @@ fieldset {
 }
 
 // Firefox only
-/* stylelint-disable function-url-quotes */
-
 @-moz-document url-prefix() {
     fieldset {
         display: table-cell;
     }
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -588,22 +576,15 @@ progress {
 
 // Firefox
 [type='number'] {
-    /* stylelint-disable property-no-vendor-prefix */
-
+    /* stylelint-disable-next-line property-no-vendor-prefix */
     -moz-appearance: textfield;
-
-    /* stylelint-enable */
 }
 
 // Webkit
 [type='number']::-webkit-inner-spin-button,
 [type='number']::-webkit-outer-spin-button {
-    /* stylelint-disable property-no-vendor-prefix */
-
+    /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: none;
-
-    /* stylelint-enable */
-
     margin: 0;
 }
 
@@ -614,9 +595,8 @@ progress {
  */
 
 [type='search'] {
-    /* stylelint-disable property-no-vendor-prefix */
+    /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: textfield; // [1]
-    /* stylelint-enable */
     outline-offset: -2px; // [2]
 }
 
@@ -627,11 +607,8 @@ progress {
 
 [type='search']::-webkit-search-cancel-button,
 [type='search']::-webkit-search-decoration {
-    /* stylelint-disable property-no-vendor-prefix */
-
+    /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: none;
-
-    /* stylelint-enable */
 }
 
 
@@ -640,14 +617,12 @@ progress {
  * 2. Change font properties to `inherit` in Safari.
  */
 
-/* stylelint-disable */
-
+/* stylelint-disable-next-line no-descending-specificity */
 ::-webkit-file-upload-button {
+    /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: button; // [1]
     font: inherit; // [2]
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -658,13 +633,11 @@ progress {
  * N.B. Shell specific.
  */
 
-/* stylelint-disable */
-
+/* stylelint-disable no-descending-specificity */
 ::-ms-clear,
 ::-ms-reveal {
     display: none;
 }
-
 /* stylelint-enable */
 
 
@@ -674,14 +647,11 @@ progress {
  * N.B. Shell specific.
  */
 
-/* stylelint-disable */
-
+/* stylelint-disable-next-line no-descending-specificity */
 ::-ms-expand {
     background-color: transparent;
     border: 0;
 }
-
-/* stylelint-enable */
 
 
 /**
@@ -718,11 +688,7 @@ progress {
 
     #{$shell-g-textual-inputs},
     textarea {
-        /* stylelint-disable property-no-vendor-prefix */
-
         background-clip: padding-box;
-
-        /* stylelint-enable */
     }
 
 
@@ -775,8 +741,7 @@ progress {
                  $shell-normalise-reset-focus-outline-width;
     }
 
-    /* stylelint-disable max-line-length */
-
+    /* stylelint-disable-next-line max-line-length */
     @if $shell-normalise-reset-apply-webkit-and-blink-focusring-if-focus-outline-style-is-applied-for-all-browsers {
         @supports (outline-color: -webkit-focus-ring-color) {
             :focus {
@@ -784,8 +749,6 @@ progress {
             }
         }
     }
-
-    /* stylelint-enable max-line-length */
 }
 
 
@@ -816,7 +779,6 @@ progress {
  */
 
 /* stylelint-disable no-descending-specificity */
-
 a,
 area,
 button,
@@ -828,7 +790,6 @@ textarea,
 [tabindex]:not([tabindex='-1']) {
     touch-action: manipulation;
 }
-
 /* stylelint-enable */
 
 

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -373,12 +373,9 @@ $shell-g-hidpi-dpi: 192dpi !default;
  * Easily target HiDPI resolutions with this media query.
  */
 
-/* stylelint-disable string-no-newline */
-
+/* stylelint-disable-next-line string-no-newline */
 $shell-g-hidpi-mq: '(min-resolution: #{$shell-g-hidpi-dpi}),
                     (min-resolution: #{$shell-g-hidpi-dppx})' !default;
-
-/* stylelint-enable */
 
 
 
@@ -387,21 +384,19 @@ $shell-g-hidpi-mq: '(min-resolution: #{$shell-g-hidpi-dpi}),
    ========================================================================= */
 
 /* stylelint-disable string-no-newline */
-
-$shell-g-textual-inputs: 'input[type="text"],
-                          input[type="search"],
-                          input[type="tel"],
-                          input[type="url"],
-                          input[type="email"],
-                          input[type="password"],
-                          input[type="month"],
-                          input[type="week"],
-                          input[type="time"],
-                          input[type="date"],
-                          input[type="datetime"],
-                          input[type="datetime-local"],
-                          input[type="number"]' !default;
-
+$shell-g-textual-inputs: 'input[type=\'text\'],
+                          input[type=\'search\'],
+                          input[type=\'tel\'],
+                          input[type=\'url\'],
+                          input[type=\'email\'],
+                          input[type=\'password\'],
+                          input[type=\'month\'],
+                          input[type=\'week\'],
+                          input[type=\'time\'],
+                          input[type=\'date\'],
+                          input[type=\'datetime\'],
+                          input[type=\'datetime-local\'],
+                          input[type=\'number\']' !default;
 /* stylelint-enable */
 
 
@@ -414,13 +409,11 @@ $shell-g-textual-inputs: 'input[type="text"],
  * Booleans.
  */
 
-/* stylelint-disable max-line-length */
-
+/* stylelint-disable-next-line max-line-length */
 $shell-normalise-reset-apply-focus-outline-style-for-all-browsers: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-normalise-reset-apply-webkit-and-blink-focusring-if-focus-outline-style-is-applied-for-all-browsers: false !default;
-
-/* stylelint-enable max-line-length */
 
 
 /**
@@ -533,8 +526,6 @@ $shell-grid-11-col-width: calc((100% / 12) * 11) !default;
 $shell-grid-12-col-width: 100% !default;
 
 
-/* stylelint-disable max-line-length */
-
 /**
  * For all grid item widths turn on the ability to apply breakpoints via
  * boolean settings then define the breakpoints, see: "Mixins/Functions ->
@@ -544,64 +535,74 @@ $shell-grid-12-col-width: 100% !default;
 // 1 col
 $shell-grid-apply-1-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-1-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 2 col
 $shell-grid-apply-2-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-2-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 3 col
 $shell-grid-apply-3-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-3-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 4 col
 $shell-grid-apply-4-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-4-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 5 col
 $shell-grid-apply-5-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-5-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 6 col
 $shell-grid-apply-6-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-6-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 7 col
 $shell-grid-apply-7-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-7-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 8 col
 $shell-grid-apply-8-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-8-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 9 col
 $shell-grid-apply-9-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-9-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 10 col
 $shell-grid-apply-10-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-10-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 11 col
 $shell-grid-apply-11-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-11-col-width-breakpoints: $shell-g-global-breakpoints !default;
 
 // 12 col
 $shell-grid-apply-12-col-width-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-grid-define-12-col-width-breakpoints: $shell-g-global-breakpoints !default;
-
-/* stylelint-enable */
 
 
 
@@ -615,8 +616,6 @@ $shell-grid-define-12-col-width-breakpoints: $shell-g-global-breakpoints !defaul
  * Apply at breakpoints" to understand how this works.
  */
 
-/* stylelint-disable max-line-length */
-
 /**
  * Text sizes.
  */
@@ -627,6 +626,7 @@ $shell-grid-define-12-col-width-breakpoints: $shell-g-global-breakpoints !defaul
 
 $shell-helper-apply-text-size-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-breakpoints: $shell-g-global-breakpoints !default;
 
 /**
@@ -636,16 +636,19 @@ $shell-helper-define-text-size-breakpoints: $shell-g-global-breakpoints !default
 // Small
 $shell-helper-apply-text-size-small-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-small-breakpoints: $shell-g-global-breakpoints !default;
 
 // X-Small
 $shell-helper-apply-text-size-x-small-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-x-small-breakpoints: $shell-g-global-breakpoints !default;
 
 // 2X-Small
 $shell-helper-apply-text-size-2x-small-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-2x-small-breakpoints: $shell-g-global-breakpoints !default;
 
 
@@ -656,47 +659,51 @@ $shell-helper-define-text-size-2x-small-breakpoints: $shell-g-global-breakpoints
 // Large
 $shell-helper-apply-text-size-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // X-Large
 $shell-helper-apply-text-size-x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 2X-Large
 $shell-helper-apply-text-size-2x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-2x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 3X-Large
 $shell-helper-apply-text-size-3x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-3x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 4X-Large
 $shell-helper-apply-text-size-4x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-4x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 5X-Large
 $shell-helper-apply-text-size-5x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-5x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 6X-Large
 $shell-helper-apply-text-size-6x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-6x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 7X-Large
 $shell-helper-apply-text-size-7x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-size-7x-large-breakpoints: $shell-g-global-breakpoints !default;
 
-/* stylelint-enable */
-
-
-/* stylelint-disable max-line-length */
 
 /**
  * Alignments.
@@ -705,22 +712,20 @@ $shell-helper-define-text-size-7x-large-breakpoints: $shell-g-global-breakpoints
 // Center
 $shell-helper-apply-text-align-center-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-align-center-breakpoints: $shell-g-global-breakpoints !default;
 
 // Left
 $shell-helper-apply-text-align-left-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-align-left-breakpoints: $shell-g-global-breakpoints !default;
 
 // Right
 $shell-helper-apply-text-align-right-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-align-right-breakpoints: $shell-g-global-breakpoints !default;
-
-/* stylelint-enable */
-
-
-/* stylelint-disable max-line-length */
 
 
 /**
@@ -729,12 +734,9 @@ $shell-helper-define-text-align-right-breakpoints: $shell-g-global-breakpoints !
 
 $shell-helper-apply-text-truncate-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-truncate-breakpoints: $shell-g-global-breakpoints !default;
 
-/* stylelint-enable */
-
-
-/* stylelint-disable max-line-length */
 
 /**
  * Word wrap and hyphenate.
@@ -742,12 +744,9 @@ $shell-helper-define-text-truncate-breakpoints: $shell-g-global-breakpoints !def
 
 $shell-helper-apply-text-wrap-word-and-hyphenate-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-text-wrap-word-and-hyphenate-breakpoints: $shell-g-global-breakpoints !default;
 
-/* stylelint-enable */
-
-
-/* stylelint-disable max-line-length */
 
 /**
  * Hide.
@@ -761,12 +760,9 @@ $shell-helper-define-hide-breakpoints: $shell-g-global-breakpoints !default;
 // Hide elements only visually but have it available for screen readers
 $shell-helper-apply-hide-visually-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-hide-visually-breakpoints: $shell-g-global-breakpoints !default;
 
-/* stylelint-enable */
-
-
-/* stylelint-disable max-line-length */
 
 /**
  * Spacing.
@@ -783,16 +779,19 @@ $shell-helper-define-spacing-breakpoints: $shell-g-global-breakpoints !default;
 // Small
 $shell-helper-apply-spacing-small-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-small-breakpoints: $shell-g-global-breakpoints !default;
 
 // X-Small
 $shell-helper-apply-spacing-x-small-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-x-small-breakpoints: $shell-g-global-breakpoints !default;
 
 // 2X-Small
 $shell-helper-apply-spacing-2x-small-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-2x-small-breakpoints: $shell-g-global-breakpoints !default;
 
 
@@ -803,36 +802,41 @@ $shell-helper-define-spacing-2x-small-breakpoints: $shell-g-global-breakpoints !
 // Large
 $shell-helper-apply-spacing-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // X-Large
 $shell-helper-apply-spacing-x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 2X-Large
 $shell-helper-apply-spacing-2x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-2x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 3X-Large
 $shell-helper-apply-spacing-3x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-3x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 4X-Large
 $shell-helper-apply-spacing-4x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-4x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 5X-Large
 $shell-helper-apply-spacing-5x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-5x-large-breakpoints: $shell-g-global-breakpoints !default;
 
 // 6X-Large
 $shell-helper-apply-spacing-6x-large-at-breakpoints: false !default;
 
+/* stylelint-disable-next-line max-line-length */
 $shell-helper-define-spacing-6x-large-breakpoints: $shell-g-global-breakpoints !default;
-
-/* stylelint-enable */

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -20,7 +20,7 @@ module.exports = {
          * http://stylelint.io/user-guide/rules/#font-family
          */
 
-        'font-family-name-quotes': 'single-where-recommended',
+        'font-family-name-quotes': 'always-where-required',
 
 
         /**
@@ -45,7 +45,7 @@ module.exports = {
         'function-linear-gradient-no-nonstandard-direction': true,
         'function-parentheses-newline-inside': 'always-multi-line',
         'function-parentheses-space-inside': 'never-single-line',
-        'function-url-quotes': 'single',
+        'function-url-quotes': 'always',
         'function-whitelist': null,
         'function-whitespace-after': 'always',
 
@@ -58,7 +58,6 @@ module.exports = {
         'number-leading-zero': 'always',
         'number-max-precision': 3,
         'number-no-trailing-zeros': true,
-        'number-zero-length-no-unit': true,
 
 
         /**
@@ -71,11 +70,19 @@ module.exports = {
 
 
         /**
+         * Length
+         * http://stylelint.io/user-guide/rules/#length
+         */
+
+        'length-zero-no-unit': true,
+
+
+        /**
          * Time
          * http://stylelint.io/user-guide/rules/#time
          */
 
-        'time-no-imperceptible': true,
+        //'time-no-imperceptible': true,
 
 
         /**
@@ -128,20 +135,6 @@ module.exports = {
 
         'property-blacklist': null,
         'property-no-vendor-prefix': true,
-        'property-unit-blacklist': null,
-        'property-unit-whitelist': {
-            'font-size': [
-                'em',
-                'rem'
-            ],
-            'letter-spacing': [
-                'em',
-                'rem'
-            ],
-            'line-height': []
-        },
-        'property-value-blacklist': null,
-        'property-value-whitelist': null,
         'property-whitelist': null,
 
 
@@ -156,6 +149,17 @@ module.exports = {
         'declaration-colon-space-after': 'always',
         'declaration-colon-space-before': 'never',
         'declaration-no-important': null,
+        'declaration-property-unit-whitelist': {
+            'font-size': [
+                'em',
+                'rem'
+            ],
+            'letter-spacing': [
+                'em',
+                'rem'
+            ],
+            'line-height': []
+        },
 
 
         /**
@@ -200,7 +204,7 @@ module.exports = {
         'selector-combinator-space-after': 'always',
         'selector-combinator-space-before': 'always',
         'selector-id-pattern': null,
-        'selector-max-specificity': '0,3,1',
+        'selector-max-specificity': '0,4,1',
         'selector-no-attribute': null,
         'selector-no-combinator': null,
         'selector-no-id': true,
@@ -209,14 +213,13 @@ module.exports = {
         //     ignore: ['descendant'],
         //     severity: 'warning'
         // }],
-        // 'selector-no-universal': [true, {
-        //     severity: 'warning'
-        // }],
+        'selector-no-universal': [true, {
+            severity: 'warning'
+        }],
         'selector-no-vendor-prefix': true,
         'selector-pseudo-element-colon-notation': 'double',
         'selector-root-no-composition': null,
-        // Not working: https://github.com/stylelint/stylelint/issues/908
-        // 'selector-type-case': 'lower',
+        'selector-type-case': 'lower',
 
 
         /**
@@ -278,7 +281,7 @@ module.exports = {
          * http://stylelint.io/user-guide/rules/#media-query
          */
 
-        'media-query-parentheses-space-inside': 'never',
+        'media-feature-parentheses-space-inside': 'never',
 
 
         /**
@@ -324,15 +327,17 @@ module.exports = {
             ignore: ['value']
         }],
         'max-empty-lines': 4,
-        'max-line-length': 80,
+        'max-line-length': [80, {
+            severity: 'warning'
+        }],
         'max-nesting-depth': 2,
         'no-browser-hacks': null,
         'no-descending-specificity': true,
         'no-duplicate-selectors': true,
         'no-eol-whitespace': true,
         'no-invalid-double-slash-comments': null,
-        'no-missing-eof-newline': true,
-        'no-unknown-animations': true,
+        'no-missing-end-of-source-newline': true,
+        //'no-unknown-animations': true,
         'no-unsupported-browser-features': null
         // Not working in Sublime Text reporting
         // 'no-unsupported-browser-features': [true, {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -45,7 +45,9 @@ module.exports = {
         'function-linear-gradient-no-nonstandard-direction': true,
         'function-parentheses-newline-inside': 'always-multi-line',
         'function-parentheses-space-inside': 'never-single-line',
-        'function-url-quotes': 'always',
+        'function-url-quotes': ['always', {
+            except: ['empty']
+        }],
         'function-whitelist': null,
         'function-whitespace-after': 'always',
 
@@ -312,7 +314,7 @@ module.exports = {
          */
 
         'comment-empty-line-before': ['always', {
-            ignore: ['between-comments'],
+            ignore: ["between-comments", "stylelint-commands"],
             except: ['first-nested']
         }],
         'comment-whitespace-inside': 'always',

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -314,7 +314,7 @@ module.exports = {
          */
 
         'comment-empty-line-before': ['always', {
-            ignore: ["between-comments", "stylelint-commands"],
+            ignore: ['between-comments', 'stylelint-commands'],
             except: ['first-nested']
         }],
         'comment-whitespace-inside': 'always',

--- a/test/package.json
+++ b/test/package.json
@@ -18,6 +18,6 @@
     "grunt-sass": "^1.1.0",
     "postcss": "^5.0.17",
     "postcss-scss": "^0.1.5",
-    "stylelint": "^6.5.1"
+    "stylelint": "^7.6.0"
   }
 }

--- a/test/src/assets/scss/_settings.scss
+++ b/test/src/assets/scss/_settings.scss
@@ -56,9 +56,12 @@ $g-color-medium-grey: #999;
 $g-color-dark-grey: #666;
 
 // Others
+/* stylelint-disable-next-line color-named */
 $g-color-dark-orange: darkorange;
 
 // Demo colours for test cases
+/* stylelint-disable-next-line color-named */
 $g-color-test-case-canvas-background: crimson;
 
+/* stylelint-disable-next-line color-named */
 $g-color-test-case-subject-background: lightblue;

--- a/test/src/assets/scss/vendor/_github-style-syntax-highlighting.scss
+++ b/test/src/assets/scss/vendor/_github-style-syntax-highlighting.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable */
+
 /**
  * GitHub style syntax highlighting by Vasily Polovnyov (vast@whiteants.net).
  *
@@ -141,3 +143,5 @@ code[class*="language-"] {
         color: #aaaaaa;
     }
 }
+
+/* stylelint-enable */


### PR DESCRIPTION
Fixes #72.

@DaveOrDead I couldn't use the `cm-stylelint` NPM module as it's private to CM, I'm going to see if I can make it public then update later.

I also set up a Gulp task: `gulp lint` which will lint all applicable `.scss` files. One day we'll get #19 going.